### PR TITLE
Price conversion using user's IP (locationcurrencyapi)

### DIFF
--- a/practice_app/pages/api/getConvertedPrice.js
+++ b/practice_app/pages/api/getConvertedPrice.js
@@ -1,0 +1,28 @@
+const PriceConversionService = require('../../services/getConvertedPrice')
+
+export default async (req, res) => {
+    try {
+        const { query, method } = req
+
+        if (method != 'GET') {
+            res.statusCode = 400
+            return res.send()
+        }
+
+        
+        const { statusCode, body } = await PriceConversionService.getConvertedPrice({
+            ip: query.ip,
+            srcCurrency: query.srcCurrency,
+            price: query.price
+        })
+
+        
+
+        res.statusCode = statusCode
+        res.json(body)
+    } catch (e) {
+        console.error(e)
+        res.statusCode = 500
+        res.json({ error: 'An unknown error occured' })
+    }
+}

--- a/practice_app/pages/api/getConvertedPrice.js
+++ b/practice_app/pages/api/getConvertedPrice.js
@@ -9,14 +9,11 @@ export default async (req, res) => {
             return res.send()
         }
 
-        
         const { statusCode, body } = await PriceConversionService.getConvertedPrice({
             ip: query.ip,
             srcCurrency: query.srcCurrency,
-            price: query.price
+            price: query.price,
         })
-
-        
 
         res.statusCode = statusCode
         res.json(body)

--- a/practice_app/pages/index.js
+++ b/practice_app/pages/index.js
@@ -5,6 +5,7 @@ import axios from 'axios'
 
 import dynamic from 'next/dynamic'
 
+
 const MapView = dynamic(() => import('../components/MapView'), { ssr: false })
 // axios is a library used to make requests
 
@@ -49,6 +50,10 @@ export default function Home({ context }) {
         name: 'Turkey',
     })
 
+    // To show visually the price conversion process
+    const [priceConversionText, setPriceConversionText] = useState("Use the button to try price conversion")
+
+
     const onMapClick = async ({ longitude, latitude }) => {
         try {
             console.log({ longitude, latitude })
@@ -75,8 +80,42 @@ export default function Home({ context }) {
         }
     }
 
+    // When the button is clicked, makes a price conversion demonstration.
+    const onConvertButtonClick = async () => {
+        try {
+            const ipdata = await getUsersIP()
+            const pricedata = await priceConverter(10, ipdata.query, "USD")
+            Promise
+            setPriceConversionText(`Your ip adress is ${ipdata.query} and currency of the country that this IP belongs to is ${pricedata.currency}.
+            If price of a product is 10 USD, then it is equal to ${pricedata.price.toFixed(2)} ${pricedata.currency} in your currency.`)
+        } catch (error) {
+            console.log(error)
+            setPriceConversionText("Sorry, service unavailable at this time.")
+        }
+    }
+
+    // Returns the IP of the user
+    const getUsersIP = async () => {
+        const {data} = await axios.get("http://ip-api.com/json/")
+        return data
+    }
+
+    // Using the given ip, finds the currency of the country that the given IP belongs to.
+    // Then, converts the given price in srcCurrency to the new currency. 
+    // Returns the result
+    const priceConverter = async (pr, ip, srcCurrency) => {
+        try {
+            const {data} = await axios.get('api/getConvertedPrice?ip='+ip+'&price='+pr+'&srcCurrency='+srcCurrency)
+            return data
+            
+        } catch (error) {
+            console.error(error) 
+        } 
+    }
+
     const locationGreeting = () =>
         `You are a user from ${country.name}, you speak ${language.name} and you buy in ${currency.name}`
+
 
     return (
         <div className="container">
@@ -92,6 +131,7 @@ export default function Home({ context }) {
             </Head>
             <main>
                 <h1>Welcome to our demo website!</h1>
+                {priceConversionText && <p>{priceConversionText}</p>}<button variant='primary' onClick={onConvertButtonClick}>Price Conversion</button>
                 {country && language && currency && <p>{locationGreeting()} </p>}
                 <MapView onMapClick={onMapClick} coordinates={coordinates} />
             </main>

--- a/practice_app/services/getConvertedPrice.js
+++ b/practice_app/services/getConvertedPrice.js
@@ -64,25 +64,12 @@ exports.getInfoCurrency = async function ({ srcCurrency, tarCurrency }) {
 }
 
 exports.getConvertedPrice = async function ({ ip, srcCurrency, price }) {
-    const ipData = exports.getInfoFromIP({ ip })
-    const result = ipData.then(ipdata => {
-        const tarCurrency = ipdata.currency
+    const ipData = await exports.getInfoFromIP({ ip })
 
-        console.log(tarCurrency)
+    const tarCurrency = ipData.currency
 
-        const currencyData = exports.getInfoCurrency({ srcCurrency, tarCurrency })
+    const currencyData = await exports.getInfoCurrency({ srcCurrency, tarCurrency })
+    const updatedPrice = currencyData.ratio * price
 
-        const { ratio } = currencyData
-
-        const { valid } = currencyData
-
-        console.log(ratio)
-
-        console.log(valid)
-
-        const updatedPrice = ratio * price
-
-        return { statusCode: 200, body: { updatedPrice, currency: tarCurrency } }
-    })
-    return result
+    return { statusCode: 200, body: {price: updatedPrice, currency: tarCurrency } }
 }

--- a/practice_app/services/getConvertedPrice.js
+++ b/practice_app/services/getConvertedPrice.js
@@ -9,7 +9,6 @@ function getCurrency(data) {
 }
 
 function getExchangeRate(data, currencyType) {
-    console.log(currencyType)
     return data.rates[currencyType]
 }
 
@@ -26,7 +25,7 @@ exports.processIPInfo = function (data) {
     }
 }
 
-exports.processCurrencyInfo = function ({ data, srcCurrency, tarCurrency }) {
+exports.processCurrencyInfo = function (data, srcCurrency, tarCurrency) {
     const tarRate = getExchangeRate(data, tarCurrency)
     const srcRate = getExchangeRate(data, srcCurrency)
 
@@ -60,7 +59,7 @@ exports.getInfoCurrency = async function ({ srcCurrency, tarCurrency }) {
 
     const { data } = await axios.get(uri)
 
-    return exports.processCurrencyInfo({ data, srcCurrency, tarCurrency })
+    return exports.processCurrencyInfo(data, srcCurrency, tarCurrency)
 }
 
 exports.getConvertedPrice = async function ({ ip, srcCurrency, price }) {

--- a/practice_app/services/getConvertedPrice.js
+++ b/practice_app/services/getConvertedPrice.js
@@ -31,7 +31,7 @@ exports.processCurrencyInfo = function (data, srcCurrency, tarCurrency) {
 
     const valid = Boolean(tarRate && srcRate)
     let ratio = null
-    if (valid) ratio = srcRate / tarRate
+    if (valid) ratio = tarRate / srcRate
 
     return {
         valid,

--- a/practice_app/services/getConvertedPrice.js
+++ b/practice_app/services/getConvertedPrice.js
@@ -1,0 +1,43 @@
+const axios = require('axios')
+
+function getCountry(data) {
+    return data.country_name
+}
+
+function getCurrency(data) {
+    return data.currency_code
+}
+
+exports.processIPInfo = function (data) {
+
+    const country = getCountry(data)
+    const currency = getCurrency(data)
+
+    const valid = Boolean(country && currency)
+
+    return {
+        valid,
+        country,
+        currency,
+    }
+}
+
+exports.getInfoFromIP = async function ({ip}) {
+    console.log('Getting the information of the ip', {ip})
+
+    const params = `${ip}`
+    const uri = `https://json.geoiplookup.io/${ip}`
+
+    const { data } = await axios.get(uri)
+
+    return exports.processIPInfo(data)
+}
+
+exports.getConvertedPrice = async function ({ip, srcCurrency, price}) {
+
+    const ipdata = exports.getInfoFromIP({ip})
+    ipdata.then(ipdata => {console.log(ipdata)})
+    
+
+    return {statusCode: 200, body: {}}
+}

--- a/practice_app/services/getConvertedPrice.js
+++ b/practice_app/services/getConvertedPrice.js
@@ -69,6 +69,8 @@ exports.getConvertedPrice = async function ({ ip, srcCurrency, price }) {
 
     const currencyData = await exports.getInfoCurrency({ srcCurrency, tarCurrency })
     const updatedPrice = currencyData.ratio * price
+    
+    const validity = currencyData.valid&&ipData.valid
 
-    return { statusCode: 200, body: {price: updatedPrice, currency: tarCurrency } }
+    return { statusCode: 200, body: {valid: validity, price: updatedPrice, currency: tarCurrency } }
 }

--- a/practice_app/services/getConvertedPrice.spec.js
+++ b/practice_app/services/getConvertedPrice.spec.js
@@ -1,0 +1,118 @@
+const { processCurrencyInfo } = require('./getConvertedPrice')
+const { processIPInfo } = require('./getConvertedPrice')
+
+// describe, test and expect functions are globals defined by Jest framework inside test files
+describe('processIPInfo', () => {
+    test('returns valid on valid input', () => {
+        const input = {
+            "country_name": "Turkey",
+            "currency_code": "TRY",
+        }
+
+        const output = processIPInfo(input)
+
+        expect(output.valid).toStrictEqual(true)
+    })
+
+    test('returns invalid on no country name', () => {
+        const input = {
+            "currency_code": "TRY"
+        }
+
+        const output = processIPInfo(input)
+
+        expect(output.valid).toStrictEqual(false)
+    })
+
+    test('returns invalid on no currency code', () => {
+        const input = {
+            "country_name": "Turkey"
+        }
+
+        const output = processIPInfo(input)
+
+        expect(output.valid).toStrictEqual(false)
+    })
+
+    test('returns invalid on bad data shape', () => {
+        const input = {
+            counter_name: "Turkia",
+            currency_coder: "TRyi"
+        }
+
+        const output = processIPInfo(input)
+
+        expect(output.valid).toStrictEqual(false)
+    })
+
+    test('returns the currency code from the input', () => {
+        const input = {
+            "ip": "159.146.10.4",
+            "isp": "TurkNet Iletisim Hizmetleri",
+            "org": "TurkNet Iletisim Hizmetleri A.S.",
+            "hostname": "159.146.10.4",
+            "latitude": 41.0082,
+            "longitude": 28.9784,
+            "postal_code": "34122",
+            "city": "Istanbul",
+            "country_code": "TR",
+            "country_name": "Turkey",
+            "continent_code": "AS",
+            "continent_name": "Asia",
+            "region": "Istanbul",
+            "district": "",
+            "timezone_name": "Europe\/Istanbul",
+            "connection_type": "Cable\/DSL",
+            "asn_number": 12735,
+            "asn_org": "TurkNet Iletisim Hizmetleri A.S.",
+            "asn": "AS12735 - TurkNet Iletisim Hizmetleri A.S.",
+            "currency_code": "TRY",
+            "currency_name": "Turkish Lira",
+            "success": true,
+            "premium": false
+        }
+
+        const output = processIPInfo(input)
+
+        expect(output.currency).toStrictEqual(input.currency_code)
+    })
+
+    test('returns the country from the input', () => {
+        const input = {
+            "ip": "159.146.10.4",
+            "isp": "TurkNet Iletisim Hizmetleri",
+            "org": "TurkNet Iletisim Hizmetleri A.S.",
+            "hostname": "159.146.10.4",
+            "latitude": 41.0082,
+            "longitude": 28.9784,
+            "postal_code": "34122",
+            "city": "Istanbul",
+            "country_code": "TR",
+            "country_name": "Turkey",
+            "continent_code": "AS",
+            "continent_name": "Asia",
+            "region": "Istanbul",
+            "district": "",
+            "timezone_name": "Europe\/Istanbul",
+            "connection_type": "Cable\/DSL",
+            "asn_number": 12735,
+            "asn_org": "TurkNet Iletisim Hizmetleri A.S.",
+            "asn": "AS12735 - TurkNet Iletisim Hizmetleri A.S.",
+            "currency_code": "TRY",
+            "currency_name": "Turkish Lira",
+            "success": true,
+            "premium": false
+        }
+
+        const output = processIPInfo(input)
+
+        expect(output.country).toEqual(input.country_name)
+    })
+
+    test('always contains the boolean property "valid"', () => {
+        const output = processIPInfo({})
+
+        expect(Object.keys(output)).toContain('valid')
+        expect(typeof output.valid).toBe('boolean')
+    })
+})

--- a/practice_app/services/getConvertedPrice.spec.js
+++ b/practice_app/services/getConvertedPrice.spec.js
@@ -5,8 +5,8 @@ const { processIPInfo } = require('./getConvertedPrice')
 describe('processIPInfo', () => {
     test('returns valid on valid input', () => {
         const input = {
-            "country_name": "Turkey",
-            "currency_code": "TRY",
+            country_name: 'Turkey',
+            currency_code: 'TRY',
         }
 
         const output = processIPInfo(input)
@@ -16,7 +16,7 @@ describe('processIPInfo', () => {
 
     test('returns invalid on no country name', () => {
         const input = {
-            "currency_code": "TRY"
+            currency_code: 'TRY',
         }
 
         const output = processIPInfo(input)
@@ -26,7 +26,7 @@ describe('processIPInfo', () => {
 
     test('returns invalid on no currency code', () => {
         const input = {
-            "country_name": "Turkey"
+            country_name: 'Turkey',
         }
 
         const output = processIPInfo(input)
@@ -36,8 +36,8 @@ describe('processIPInfo', () => {
 
     test('returns invalid on bad data shape', () => {
         const input = {
-            counter_name: "Turkia",
-            currency_coder: "TRyi"
+            counter_name: 'Turkia',
+            currency_coder: 'TRyi',
         }
 
         const output = processIPInfo(input)
@@ -47,29 +47,29 @@ describe('processIPInfo', () => {
 
     test('returns the currency code from the input', () => {
         const input = {
-            "ip": "159.146.10.4",
-            "isp": "TurkNet Iletisim Hizmetleri",
-            "org": "TurkNet Iletisim Hizmetleri A.S.",
-            "hostname": "159.146.10.4",
-            "latitude": 41.0082,
-            "longitude": 28.9784,
-            "postal_code": "34122",
-            "city": "Istanbul",
-            "country_code": "TR",
-            "country_name": "Turkey",
-            "continent_code": "AS",
-            "continent_name": "Asia",
-            "region": "Istanbul",
-            "district": "",
-            "timezone_name": "Europe\/Istanbul",
-            "connection_type": "Cable\/DSL",
-            "asn_number": 12735,
-            "asn_org": "TurkNet Iletisim Hizmetleri A.S.",
-            "asn": "AS12735 - TurkNet Iletisim Hizmetleri A.S.",
-            "currency_code": "TRY",
-            "currency_name": "Turkish Lira",
-            "success": true,
-            "premium": false
+            ip: '159.146.10.4',
+            isp: 'TurkNet Iletisim Hizmetleri',
+            org: 'TurkNet Iletisim Hizmetleri A.S.',
+            hostname: '159.146.10.4',
+            latitude: 41.0082,
+            longitude: 28.9784,
+            postal_code: '34122',
+            city: 'Istanbul',
+            country_code: 'TR',
+            country_name: 'Turkey',
+            continent_code: 'AS',
+            continent_name: 'Asia',
+            region: 'Istanbul',
+            district: '',
+            timezone_name: 'Europe/Istanbul',
+            connection_type: 'Cable/DSL',
+            asn_number: 12735,
+            asn_org: 'TurkNet Iletisim Hizmetleri A.S.',
+            asn: 'AS12735 - TurkNet Iletisim Hizmetleri A.S.',
+            currency_code: 'TRY',
+            currency_name: 'Turkish Lira',
+            success: true,
+            premium: false,
         }
 
         const output = processIPInfo(input)
@@ -79,29 +79,29 @@ describe('processIPInfo', () => {
 
     test('returns the country from the input', () => {
         const input = {
-            "ip": "159.146.10.4",
-            "isp": "TurkNet Iletisim Hizmetleri",
-            "org": "TurkNet Iletisim Hizmetleri A.S.",
-            "hostname": "159.146.10.4",
-            "latitude": 41.0082,
-            "longitude": 28.9784,
-            "postal_code": "34122",
-            "city": "Istanbul",
-            "country_code": "TR",
-            "country_name": "Turkey",
-            "continent_code": "AS",
-            "continent_name": "Asia",
-            "region": "Istanbul",
-            "district": "",
-            "timezone_name": "Europe\/Istanbul",
-            "connection_type": "Cable\/DSL",
-            "asn_number": 12735,
-            "asn_org": "TurkNet Iletisim Hizmetleri A.S.",
-            "asn": "AS12735 - TurkNet Iletisim Hizmetleri A.S.",
-            "currency_code": "TRY",
-            "currency_name": "Turkish Lira",
-            "success": true,
-            "premium": false
+            ip: '159.146.10.4',
+            isp: 'TurkNet Iletisim Hizmetleri',
+            org: 'TurkNet Iletisim Hizmetleri A.S.',
+            hostname: '159.146.10.4',
+            latitude: 41.0082,
+            longitude: 28.9784,
+            postal_code: '34122',
+            city: 'Istanbul',
+            country_code: 'TR',
+            country_name: 'Turkey',
+            continent_code: 'AS',
+            continent_name: 'Asia',
+            region: 'Istanbul',
+            district: '',
+            timezone_name: 'Europe/Istanbul',
+            connection_type: 'Cable/DSL',
+            asn_number: 12735,
+            asn_org: 'TurkNet Iletisim Hizmetleri A.S.',
+            asn: 'AS12735 - TurkNet Iletisim Hizmetleri A.S.',
+            currency_code: 'TRY',
+            currency_name: 'Turkish Lira',
+            success: true,
+            premium: false,
         }
 
         const output = processIPInfo(input)
@@ -111,6 +111,89 @@ describe('processIPInfo', () => {
 
     test('always contains the boolean property "valid"', () => {
         const output = processIPInfo({})
+
+        expect(Object.keys(output)).toContain('valid')
+        expect(typeof output.valid).toBe('boolean')
+    })
+})
+describe('processCurrencyInfo', () => {
+    test('returns valid on valid input', () => {
+        const input = {
+            rates: { CAD: 1.5211, HKD: 8.4926, ISK: 156.5 },
+        }
+
+        const output = processCurrencyInfo(input, 'CAD', 'HKD')
+
+        expect(output.valid).toStrictEqual(true)
+    })
+
+    test('returns invalid on no target currency', () => {
+        const input = {
+            rates: { CAD: 1.5211, ISK: 156.5 },
+        }
+
+        const output = processCurrencyInfo(input, 'CAD', 'HKD')
+
+        expect(output.valid).toStrictEqual(false)
+    })
+
+    test('returns invalid on no source currency', () => {
+        const input = {
+            rates: { HKD: 8.4926, ISK: 156.5 },
+        }
+
+        const output = processCurrencyInfo(input, 'CAD', 'HKD')
+
+        expect(output.valid).toStrictEqual(false)
+    })
+
+    test('returns invalid on bad data shape', () => {
+        const input = {
+            rates: { CADI: 1.5211, HKDI: 8.4926, ISK: 156.5 },
+        }
+
+        const output = processCurrencyInfo(input, 'CAD', 'HKD')
+
+        expect(output.valid).toStrictEqual(false)
+    })
+
+    test('returns the target currency rate from the input', () => {
+        const input = {
+            rates: {
+                CAD: 1.5211,
+                HKD: 8.4926,
+                ISK: 156.5,
+                PHP: 55.447,
+                DKK: 7.4565,
+            },
+        }
+
+        const output = processCurrencyInfo(input, 'CAD', 'HKD')
+
+        expect(output.tarRate).toStrictEqual(input.rates.HKD)
+    })
+
+    test('returns the source currency rate from the input', () => {
+        const input = {
+            rates: {
+                CAD: 1.5211,
+                HKD: 8.4926,
+                ISK: 156.5,
+                PHP: 55.447,
+                DKK: 7.4565,
+            },
+        }
+
+        const output = processCurrencyInfo(input, 'CAD', 'HKD')
+
+        expect(output.srcRate).toStrictEqual(input.rates.CAD)
+    })
+
+    test('always contains the boolean property "valid"', () => {
+        const input = {
+            rates: {},
+        }
+        const output = processCurrencyInfo(input)
 
         expect(Object.keys(output)).toContain('valid')
         expect(typeof output.valid).toBe('boolean')


### PR DESCRIPTION
We have added the route `/api/getConvertedPrice` to our API.

This route gets an IP adress, finds its the currency of the country that this IP adress belongs to. It also gets a price in some currency. Then converts the price into the new currency (one that belongs to the IP adress) using the up to date exchange rates. Responses the conversion result.

It accepts a GET Request with 3 parameters:

- ip: any valid ip adress
- price: a number representing the price
- srcCurrency: a currency code (TRY for example)

It responds with 2 pieces of information:

- price: converted price
- currency: currency of the new price

We added unit tests for our functions. Our code is compatible with all the unit tests up until now.

We also added a small demonstration in the index.js page. You click a button and see the result of the conversion on 10 USD price.