### PR TITLE
[FRONTEND] Logged in user's info in top bar

### DIFF
--- a/ecommerce/frontend/src/components/layout/Header.js
+++ b/ecommerce/frontend/src/components/layout/Header.js
@@ -1,21 +1,68 @@
 import './Layout_common.less'
-import { Layout, Menu } from 'antd'
+import { Layout, Menu, Avatar, Dropdown, Button } from 'antd'
+import { UserOutlined, LogoutOutlined } from '@ant-design/icons'
 import { Link } from 'react-router-dom'
+import { useContext } from 'react'
+import { useAppContext } from '../../context/AppContext'
+
+export const GuestHeaderContent = () => {
+    return (
+        <Menu className="header-menu" mode="horizontal">
+            <Menu.Item key="login">
+                <Link to="/login">Login</Link>
+            </Menu.Item>
+            <Menu.Item key="signup">
+                <Link to="/signup">Sign up</Link>
+            </Menu.Item>
+        </Menu>
+    )
+}
+
+export const CustomerHeaderContent = () => {
+    const { user, logout } = useAppContext()
+
+    const onMenuItemClick = ({ key }) => {
+        if (key === 'logout') {
+            logout()
+        }
+    }
+
+    const dropdownMenu = () => {
+        return (
+            <Menu onClick={onMenuItemClick}>
+                <Menu.Item key="logout" icon={<LogoutOutlined />}>
+                    Logout
+                </Menu.Item>
+            </Menu>
+        )
+    }
+
+    return (
+        <div className="header-customer">
+            <Dropdown overlay={dropdownMenu()} placement={'bottomRight'} trigger="click">
+                <Button className="header-customer-info" ghost>
+                    <Avatar shape="square" size="large" icon={<UserOutlined />} />
+                    <div className="header-customer-info-details">
+                        <div className="header-customer-info-details-name">
+                            {user.name} {user.surname}
+                        </div>
+                        <div className="header-customer-info-details-email">{user.email}</div>
+                    </div>
+                </Button>
+            </Dropdown>
+        </div>
+    )
+}
 
 export const Header = () => {
+    const { user } = useAppContext()
+
     return (
         <Layout.Header className="header">
             <div className="header-logo">
                 <Link to="/">GETFLIX</Link>
             </div>
-            <Menu className="header-menu" mode="horizontal">
-                <Menu.Item key="login">
-                    <Link to="/login">Login</Link>
-                </Menu.Item>
-                <Menu.Item key="signup">
-                    <Link to="/signup">Sign up</Link>
-                </Menu.Item>
-            </Menu>
+            {user.type === 'guest' ? <GuestHeaderContent /> : <CustomerHeaderContent />}
         </Layout.Header>
     )
 }

--- a/ecommerce/frontend/src/components/layout/Layout_common.less
+++ b/ecommerce/frontend/src/components/layout/Layout_common.less
@@ -30,3 +30,34 @@
 .footer-col {
     flex: 1 0 auto;
 }
+
+.header-customer-info {
+    // float: right;
+    display: flex;
+    line-height: normal;
+    align-items: center;
+    gap: 10px;
+    height: 100%;
+    padding-left: 10px;
+    padding-right: 10px;
+}
+
+.header-customer-info-details {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+}
+.header-customer-info-details-name {
+    font-weight: bold;
+}
+
+.header-customer-info-details-email {
+    font-style: italic;
+}
+
+.header-customer {
+    display: flex;
+    padding: 5px;
+    height: 100%;
+    float: right;
+}

--- a/ecommerce/frontend/src/context/AppContext.js
+++ b/ecommerce/frontend/src/context/AppContext.js
@@ -1,11 +1,21 @@
+import { notification } from 'antd'
 import constate from 'constate'
 import { useState } from 'react'
 
+const guestUser = { type: 'guest' }
+const customerUser = { type: 'customer', name: 'Mehdi', surname: 'Saffar', email: 'example@gmail.com' }
+
 function useApp() {
-    const [user, setUser] = useState(null)
+    const [user, setUser] = useState(customerUser)
+    const logout = () => {
+        console.log('logout')
+        notification.success({ message: 'Logout', description: `See you soon, ${user.name}!` })
+        setUser(guestUser)
+    }
 
     return {
         user,
+        logout,
         setUser,
     }
 }


### PR DESCRIPTION
## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Description

Logged in users will have their login info (name, surname, email, profile picture) in top right region of the top bar. Currently profile picture has only an avatar.

# Screenshots

![image](https://user-images.githubusercontent.com/13124263/99692365-4c19f880-2a9b-11eb-825a-25d5e0a97e53.png)


# Test results

No tests.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have checked my code and corrected any misspellings
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# Potential problems/Important remarks

- missing for vendor
- fake logout for now since we are not holding any token or sort of thing like that right now